### PR TITLE
feat(bug-reporter): auto-mount MyBugsPanel via side-drawer

### DIFF
--- a/components/bug-reporter-wrapper.tsx
+++ b/components/bug-reporter-wrapper.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { BugReporterProvider } from '@boobalan_jkkn/bug-reporter-sdk';
+import { BugReporterProvider, MyBugsPanel } from '@boobalan_jkkn/bug-reporter-sdk';
 import { useEffect, useState } from 'react';
+import { Bug, X } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import type { User, AuthChangeEvent, Session } from '@supabase/supabase-js';
 
@@ -43,6 +44,51 @@ export function BugReporterWrapper({ children }: { children: React.ReactNode }) 
       } : undefined}
     >
       {children}
+      {user && <MyBugsDrawer />}
     </BugReporterProvider>
+  );
+}
+
+function MyBugsDrawer() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="View my submitted bugs"
+        className="fixed bottom-20 right-6 z-[60] flex items-center gap-2 rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-lg hover:bg-blue-700 transition-colors"
+      >
+        <Bug className="h-4 w-4" />
+        My Bugs
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="My submitted bugs"
+          className="fixed inset-0 z-[70] flex justify-end bg-black/50 backdrop-blur-sm"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="h-full w-full max-w-2xl overflow-y-auto bg-white p-6 shadow-2xl dark:bg-gray-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold">My Submitted Bugs</h2>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="rounded-md p-1 hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <MyBugsPanel />
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Rolls out the canonical "auto-mount MyBugsPanel" pattern (originally landed in devangar-plus) to flywheel-coach.

Adds a "My Bugs" floating action button + side-drawer overlay alongside the existing SDK red bug-report button:
- Floating button positioned at `bottom-20 right-6 z-[60]` (sits just above the SDK's report-bug FAB at `bottom-6 right-6`)
- Click opens a max-w-2xl right-side overlay drawer at `z-[70]` with `MyBugsPanel` from `@boobalan_jkkn/bug-reporter-sdk`
- Backdrop click and X button both close the drawer
- Gated on `user !== null` (logged-in users only) — same gate already applied to `BugReporterProvider`'s `userContext`
- Existing `BugReporterProvider`, Supabase auth wiring, and `userContext` derivation untouched

Single-file change: `components/bug-reporter-wrapper.tsx` (+47 / -1).

## DRAFT — verification deferred

Local Chrome bridge offline; cannot run browser-test handshake. Marking DRAFT.

To advance Ready:
1. Run `npm run dev`, log in, confirm "My Bugs" button visible bottom-right above the existing red bug FAB
2. Click — confirm drawer slides in from right with MyBugsPanel populated
3. Confirm backdrop click + X close
4. Attach localhost screenshot to PR description
5. `gh pr ready`

## Test plan
- [ ] Logged-out: only the SDK red button visible (no "My Bugs" button)
- [ ] Logged-in: both buttons visible, no overlap
- [ ] Drawer opens and renders MyBugsPanel
- [ ] Backdrop click closes; X button closes
- [ ] Dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)